### PR TITLE
feat: add right-side table of contents

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import Header from "@/components/Header";
 import CodeBlock from "@/components/CodeBlock";
 import ExplainRow from "@/components/ExplainRow";
 import LoopVideo from "@/components/illustrations/LoopVideo";
+import TOC from "@/components/TOC";
 
 import { IM2COL_FULL, STEP4, STEP1, STEP2, STEP3 } from "@/lib/code/im2col";
 
@@ -10,6 +11,7 @@ export default function Page() {
   return (
     <>
       <Header />
+      <TOC />
 
       <main>
         {/* HERO */}

--- a/src/components/TOC.tsx
+++ b/src/components/TOC.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type Heading = {
+  id: string;
+  text: string;
+};
+
+function slugify(text: string) {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\u0400-\u04FF\s-]/g, '')
+    .replace(/\s+/g, '-');
+}
+
+export default function TOC() {
+  const [headings, setHeadings] = useState<Heading[]>([]);
+  const [active, setActive] = useState<string>('');
+  const [isLarge, setIsLarge] = useState(false);
+
+  // Track viewport width to hide TOC on small screens
+  useEffect(() => {
+    const mql = window.matchMedia('(min-width: 1024px)');
+    const handle = (e: MediaQueryListEvent | MediaQueryList) => {
+      // MediaQueryListEvent for addEventListener, MediaQueryList for initial call
+      setIsLarge(e.matches);
+    };
+    handle(mql);
+    mql.addEventListener('change', handle);
+    return () => mql.removeEventListener('change', handle);
+  }, []);
+
+  // Gather headings and observe active section only on large screens
+  useEffect(() => {
+    if (!isLarge) return;
+
+    const elements = Array.from(
+      document.querySelectorAll('main h2, main h3')
+    ) as HTMLElement[];
+
+    const hs = elements.map((el) => {
+      const text = el.textContent || '';
+      if (!el.id) {
+        el.id = slugify(text);
+      }
+      return { id: el.id, text };
+    });
+
+    setHeadings(hs);
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActive(entry.target.id);
+          }
+        });
+      },
+      { rootMargin: '0px 0px -70% 0px' }
+    );
+
+    elements.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [isLarge]);
+
+  if (!isLarge || headings.length === 0) return null;
+
+  return (
+    <aside className="fixed top-32 right-8 w-48 text-sm">
+      <div className="mb-2 text-xs text-slate-500">On this page</div>
+      <ul className="relative border-s border-slate-200 ps-4 space-y-2">
+        {headings.map((h) => (
+          <li key={h.id} className="relative">
+            <a
+              href={`#${h.id}`}
+              className={`${active === h.id ? 'font-bold' : ''} block hover:underline`}
+            >
+              {h.text}
+            </a>
+            {active === h.id && (
+              <span className="absolute -left-4 top-1/2 h-3/4 w-px -translate-y-1/2 bg-slate-700" />
+            )}
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add client-side TOC component with scroll spy highlighting
- mount the TOC on the main page
- hide TOC on small screens and align active marker with vertical guide

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (prompts for ESLint configuration)
- `npm run build` (fails: Failed to fetch `Inter` and `Fira Code` fonts)


------
https://chatgpt.com/codex/tasks/task_e_689b475f76808322bd3384358b8f6170