### PR TITLE
feat: add docs navigation and pagination

### DIFF
--- a/src/app/hello/page.tsx
+++ b/src/app/hello/page.tsx
@@ -1,0 +1,13 @@
+import DocPage from "@/components/DocPage";
+
+export default function HelloPage() {
+  return (
+    <DocPage slug="hello">
+      <section className="max-w-[1100px] mx-auto px-4 py-10">
+        <h1 className="text-2xl font-bold mb-4">Hello</h1>
+        <p className="text-slate-700">Эта страница создана для демонстрации новой навигации.</p>
+      </section>
+    </DocPage>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 // app/page.tsx
-import Header from "@/components/Header";
+import DocPage from "@/components/DocPage";
 import CodeBlock from "@/components/CodeBlock";
 import ExplainRow from "@/components/ExplainRow";
 import LoopVideo from "@/components/illustrations/LoopVideo";
@@ -9,8 +9,7 @@ import { IM2COL_FULL, STEP4, STEP1, STEP2, STEP3 } from "@/lib/code/im2col";
 
 export default function Page() {
   return (
-    <>
-      <Header />
+    <DocPage slug="im2col">
       <div className="flex justify-center relative lg:px-8">
         <main className="max-w-[1100px] w-full px-4">
           {/* HERO */}
@@ -101,6 +100,6 @@ export default function Page() {
           <TOC />
         </div>
       </div>
-    </>
+    </DocPage>
   );
 }

--- a/src/components/DocPage.tsx
+++ b/src/components/DocPage.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+import Header from "@/components/Header";
+import { DOCS } from "@/lib/docs";
+
+interface DocPageProps {
+  slug: string;
+  children: ReactNode;
+}
+
+export default function DocPage({ slug, children }: DocPageProps) {
+  const index = DOCS.findIndex((d) => d.slug === slug);
+  const prev = index > 0 ? DOCS[index - 1] : null;
+  const next = index < DOCS.length - 1 ? DOCS[index + 1] : null;
+
+  return (
+    <>
+      <Header />
+      <div className="flex">
+        <aside className="hidden md:block w-48 shrink-0 border-r border-slate-200 p-4">
+          <nav className="space-y-2">
+            {DOCS.map((doc) => (
+              <Link
+                key={doc.slug}
+                href={doc.href}
+                className={
+                  doc.slug === slug
+                    ? "block font-bold text-slate-900"
+                    : "block text-slate-600 hover:text-slate-900"
+                }
+              >
+                {doc.title}
+              </Link>
+            ))}
+          </nav>
+        </aside>
+        <main className="flex-1 p-4">
+          {children}
+          <div className="flex justify-between mt-8">
+            {prev ? (
+              <Link href={prev.href} className="text-slate-600 hover:text-slate-900">
+                ← {prev.title}
+              </Link>
+            ) : (
+              <span />
+            )}
+            {next ? (
+              <Link href={next.href} className="text-slate-600 hover:text-slate-900">
+                {next.title} →
+              </Link>
+            ) : (
+              <span />
+            )}
+          </div>
+        </main>
+      </div>
+    </>
+  );
+}
+

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,0 +1,11 @@
+export interface DocPageInfo {
+  slug: string;
+  title: string;
+  href: string;
+}
+
+export const DOCS: DocPageInfo[] = [
+  { slug: 'im2col', title: 'im2col', href: '/' },
+  { slug: 'hello', title: 'Hello', href: '/hello' },
+];
+


### PR DESCRIPTION
## Summary
- add generic DocPage with sidebar links and prev/next navigation
- create sample `hello` doc page using new template
- wrap existing `im2col` page with DocPage

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Failed to fetch Fira Code/Inter from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689b64b5442c83228f0d5cd76c541aca