### PR TITLE
feat: add docs navigation and pagination

### DIFF
--- a/src/app/hello/page.tsx
+++ b/src/app/hello/page.tsx
@@ -1,0 +1,13 @@
+import DocPage from "@/components/DocPage";
+
+export default function HelloPage() {
+  return (
+    <DocPage slug="hello">
+      <section className="py-10">
+        <h1 className="text-2xl font-bold mb-4">Hello</h1>
+        <p className="text-slate-700">Эта страница создана для демонстрации новой навигации.</p>
+      </section>
+    </DocPage>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,106 +1,94 @@
 // app/page.tsx
-import Header from "@/components/Header";
+import DocPage from "@/components/DocPage";
 import CodeBlock from "@/components/CodeBlock";
 import ExplainRow from "@/components/ExplainRow";
 import LoopVideo from "@/components/illustrations/LoopVideo";
-import TOC from "@/components/TOC";
 
 import { IM2COL_FULL, STEP4, STEP1, STEP2, STEP3 } from "@/lib/code/im2col";
 
 export default function Page() {
   return (
-    <>
-      <Header />
-      <div className="flex justify-center relative lg:px-8">
-        <main className="max-w-[1100px] w-full px-4">
-          {/* HERO */}
-          <section className="max-w-[1100px] mx-auto lg:mx-0 px-4 pt-10">
-            <div className="rounded-2xl border border-slate-200 bg-white shadow-sm p-4">
-              <div className="flex items-center justify-between mb-3">
-                <h2 className="m-0 text-lg font-bold tracking-tight">
-                  Функция{" "}
-                  <code className="font-[var(--font-fira)]">im2col</code>{" "}
-                  (Python)
-                </h2>
-              </div>
+    <DocPage slug="im2col">
+      {/* HERO */}
+      <section className="pt-10">
+        <div className="rounded-2xl border border-slate-200 bg-white shadow-sm p-4">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="m-0 text-lg font-bold tracking-tight">
+              Функция{" "}
+              <code className="font-[var(--font-fira)]">im2col</code>{" "}
+              (Python)
+            </h2>
+          </div>
 
-              <CodeBlock
-                title="Python"
-                language="python"
-                code={IM2COL_FULL}
-                expandable
-              />
-            </div>
-          </section>
-
-          {/* ПОЯСНЕНИЯ */}
-          <section
-            id="explain"
-            className="max-w-[1300px] mx-auto lg:mx-0 px-4 py-8 space-y-12"
-          >
-            <div className="h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
-
-            <ExplainRow
-              caption="Шаг 1 — Параметры и размеры выхода"
-              code={STEP1}
-              right={
-                <LoopVideo
-                  src="/videos/ScalarRowMatrixWH_v10.mp4"
-                  poster="/videos/ScalarRowMatrixWH_v10.png"
-                  // кастомный размер/обёртка через tailwind:
-                  className="rounded-2xl border border-slate-200 shadow-md overflow-hidden aspect-video bg-black"
-                />
-              }
-            />
-            <div className="h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
-
-            <ExplainRow
-              caption="Шаг 2 — Параметры и размеры выхода"
-              code={STEP2}
-              right={
-                <LoopVideo
-                  src="/videos/HelloManim.mp4"
-                  poster="/videos/HelloManim.png"
-                  // кастомный размер/обёртка через tailwind:
-                  className="rounded-2xl border border-slate-200 shadow-md overflow-hidden aspect-video bg-black"
-                />
-              }
-            />
-            <div className="h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
-
-            <ExplainRow
-              caption="Шаг 3 — Паддинг и буфер cols"
-              code={STEP3}
-              right={
-                <LoopVideo
-                  src="/videos/demo.mp4"
-                  poster="/videos/image.png"
-                  // кастомный размер/обёртка через tailwind:
-                  className="rounded-2xl border border-slate-200 shadow-md overflow-hidden aspect-video bg-black"
-                />
-              }
-            />
-
-            <div className="h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
-
-            <ExplainRow
-              caption="Шаг 4 — Из тензора в матрицу для GEMM"
-              code={STEP4}
-              right={
-                <LoopVideo
-                  src="/videos/cols_reshape.mp4"
-                  poster="/videos/cols_reshape.png"
-                  // кастомный размер/обёртка через tailwind:
-                  className="rounded-2xl border border-slate-200 shadow-md overflow-hidden aspect-video bg-black"
-                />
-              }
-            />
-          </section>
-        </main>
-        <div className="hidden lg:block sticky top-32 w-48 shrink-0 ml-8">
-          <TOC />
+          <CodeBlock
+            title="Python"
+            language="python"
+            code={IM2COL_FULL}
+            expandable
+          />
         </div>
-      </div>
-    </>
+      </section>
+
+      {/* ПОЯСНЕНИЯ */}
+      <section id="explain" className="py-8 space-y-12">
+        <div className="h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
+
+        <ExplainRow
+          caption="Шаг 1 — Параметры и размеры выхода"
+          code={STEP1}
+          right={
+            <LoopVideo
+              src="/videos/ScalarRowMatrixWH_v10.mp4"
+              poster="/videos/ScalarRowMatrixWH_v10.png"
+              // кастомный размер/обёртка через tailwind:
+              className="rounded-2xl border border-slate-200 shadow-md overflow-hidden aspect-video bg-black"
+            />
+          }
+        />
+        <div className="h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
+
+        <ExplainRow
+          caption="Шаг 2 — Параметры и размеры выхода"
+          code={STEP2}
+          right={
+            <LoopVideo
+              src="/videos/HelloManim.mp4"
+              poster="/videos/HelloManim.png"
+              // кастомный размер/обёртка через tailwind:
+              className="rounded-2xl border border-slate-200 shadow-md overflow-hidden aspect-video bg-black"
+            />
+          }
+        />
+        <div className="h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
+
+        <ExplainRow
+          caption="Шаг 3 — Паддинг и буфер cols"
+          code={STEP3}
+          right={
+            <LoopVideo
+              src="/videos/demo.mp4"
+              poster="/videos/image.png"
+              // кастомный размер/обёртка через tailwind:
+              className="rounded-2xl border border-slate-200 shadow-md overflow-hidden aspect-video bg-black"
+            />
+          }
+        />
+
+        <div className="h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
+
+        <ExplainRow
+          caption="Шаг 4 — Из тензора в матрицу для GEMM"
+          code={STEP4}
+          right={
+            <LoopVideo
+              src="/videos/cols_reshape.mp4"
+              poster="/videos/cols_reshape.png"
+              // кастомный размер/обёртка через tailwind:
+              className="rounded-2xl border border-slate-200 shadow-md overflow-hidden aspect-video bg-black"
+            />
+          }
+        />
+      </section>
+    </DocPage>
   );
 }

--- a/src/components/DocPage.tsx
+++ b/src/components/DocPage.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+import Header from "@/components/Header";
+import TOC from "@/components/TOC";
+import { DOCS } from "@/lib/docs";
+
+interface DocPageProps {
+  slug: string;
+  children: ReactNode;
+}
+
+export default function DocPage({ slug, children }: DocPageProps) {
+  const index = DOCS.findIndex((d) => d.slug === slug);
+  const prev = index > 0 ? DOCS[index - 1] : null;
+  const next = index < DOCS.length - 1 ? DOCS[index + 1] : null;
+
+  return (
+    <>
+      <Header />
+      <div className="flex">
+        <aside className="hidden md:block w-48 shrink-0 border-r border-slate-200 p-4">
+          <nav className="space-y-1">
+            {DOCS.map((doc) => (
+              <Link
+                key={doc.slug}
+                href={doc.href}
+                className={
+                  doc.slug === slug
+                    ? "block rounded px-2 py-1 bg-slate-100 font-medium text-slate-900"
+                    : "block rounded px-2 py-1 text-slate-600 hover:bg-slate-50 hover:text-slate-900"
+                }
+              >
+                {doc.title}
+              </Link>
+            ))}
+          </nav>
+        </aside>
+        <div className="flex-1 flex justify-center relative lg:px-8">
+          <main className="max-w-[1100px] w-full px-4">
+            {children}
+            <div className="flex justify-between mt-8">
+              {prev ? (
+                <Link href={prev.href} className="text-slate-600 hover:text-slate-900">
+                  ← {prev.title}
+                </Link>
+              ) : (
+                <span />
+              )}
+              {next ? (
+                <Link href={next.href} className="text-slate-600 hover:text-slate-900">
+                  {next.title} →
+                </Link>
+              ) : (
+                <span />
+              )}
+            </div>
+          </main>
+          <div className="hidden lg:block sticky top-32 w-48 shrink-0 ml-8">
+            <TOC />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,0 +1,11 @@
+export interface DocPageInfo {
+  slug: string;
+  title: string;
+  href: string;
+}
+
+export const DOCS: DocPageInfo[] = [
+  { slug: 'im2col', title: 'im2col', href: '/' },
+  { slug: 'hello', title: 'Hello', href: '/hello' },
+];
+


### PR DESCRIPTION
## Summary
- centralize documentation layout in `DocPage` with sidebar, TOC, and prev/next links
- simplify `im2col` and `hello` pages to use new `DocPage` structure

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Failed to fetch font files)*

------
https://chatgpt.com/codex/tasks/task_e_689b64b5442c83228f0d5cd76c541aca